### PR TITLE
eli's keychron q1 ansi keymap

### DIFF
--- a/keyboards/keychron/q1/ansi/keymaps/eli/config.h
+++ b/keyboards/keychron/q1/ansi/keymaps/eli/config.h
@@ -1,0 +1,23 @@
+/* Copyright 2021 @ Mike Killewald
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef RGB_MATRIX_ENABLE
+#    define RGB_DISABLE_WHEN_USB_SUSPENDED
+#    define CAPS_LOCK_INDICATOR_COLOR RGB_RED
+#    define FN_LAYER_COLOR RGB_GREEN
+#endif

--- a/keyboards/keychron/q1/ansi/keymaps/eli/keymap.c
+++ b/keyboards/keychron/q1/ansi/keymaps/eli/keymap.c
@@ -1,0 +1,153 @@
+/* Copyright 2021 @ Mike Killewald
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "keymap_user.h"
+#ifdef RGB_MATRIX_ENABLE
+#    include "rgb_matrix_user.h"
+#endif
+
+// clang-format off
+
+typedef union {
+  uint32_t raw;
+  struct {
+    bool caps_lock_light_tab :1;
+    bool caps_lock_light_alphas :1;
+    bool fn_layer_transparent_keys_off :1;
+    bool fn_layer_color_enable :1;
+  };
+} user_config_t;
+
+user_config_t user_config;
+
+enum custom_keycodes {
+    KC_LIGHT_TAB_TOGGLE = QK_KB_2, // TECH DEBT: Starts at QK_KB_2 to maintain ordering with VIA definitions. See #19884. Revert to QK_KB_0 when VIA catches up with QMK.
+    KC_LIGHT_ALPHAS_TOGGLE,
+    KC_FN_LAYER_TRANSPARENT_KEYS_TOGGLE,
+    KC_FN_LAYER_COLOR_TOGGLE
+};
+
+#define KC_LTTOG KC_LIGHT_TAB_TOGGLE
+#define KC_LATOG KC_LIGHT_ALPHAS_TOGGLE
+#define KC_TKTOG KC_FN_LAYER_TRANSPARENT_KEYS_TOGGLE
+#define KC_FCTOG KC_FN_LAYER_COLOR_TOGGLE
+#define KC_TASK LGUI(KC_TAB)
+#define KC_FLXP LGUI(KC_E)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+[MAC_BASE] = LAYOUT_ansi_82(
+     KC_ESC,             KC_BRID,  KC_BRIU,  KC_MCTL,  KC_LPAD,  RGB_VAD,  RGB_VAI,  KC_MPRV,  KC_MPLY,  KC_MNXT,  KC_MUTE,  KC_VOLD,  KC_VOLU,  KC_DEL,   KC_INS,
+     KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,            KC_HOME,
+     KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,            KC_PGUP,
+     KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,             KC_PGDN,
+     KC_LSFT,            KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,            KC_RSFT,  KC_UP,
+     KC_LCTL,  KC_LALT,  KC_LGUI,                                KC_SPC,                                 KC_RGUI, MO(MAC_FN),KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT),
+
+[MAC_FN] = LAYOUT_ansi_82(
+     KC_TRNS,            KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_TRNS,  KC_TRNS,
+     KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,
+     RGB_TOG,  RGB_MOD,  RGB_VAI,  RGB_HUI,  RGB_SAI,  RGB_SPI,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,
+     KC_TRNS,  RGB_RMOD, RGB_VAD,  RGB_HUD,  RGB_SAD,  RGB_SPD,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,            KC_TRNS,
+     KC_TRNS,            KC_LTTOG, KC_LATOG, KC_TKTOG, KC_FCTOG, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,  KC_TRNS,
+     KC_TRNS,  KC_TRNS,  KC_TRNS,                                KC_TRNS,                                KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS),
+
+[WIN_BASE] = LAYOUT_ansi_82(
+     KC_ESC,             KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_DEL,   KC_INS,
+     KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,     KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,            KC_HOME,
+     KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,            KC_PGUP,
+     KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,             KC_PGDN,
+     KC_LSFT,            KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,            KC_RSFT,  KC_UP,
+     KC_LCTL,  KC_LGUI,  KC_LALT,                                KC_SPC,                                 KC_RALT, MO(WIN_FN),KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT),
+
+[WIN_FN] = LAYOUT_ansi_82(
+     KC_TRNS,            KC_BRID,  KC_BRIU,  KC_TASK,  KC_FLXP,  RGB_VAD,  RGB_VAI,  KC_MPRV,  KC_MPLY,  KC_MNXT,  KC_MUTE,  KC_VOLD,  KC_VOLU,  KC_TRNS,  KC_TRNS,
+     KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,
+     RGB_TOG,  RGB_MOD,  RGB_VAI,  RGB_HUI,  RGB_SAI,  RGB_SPI,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,
+     KC_TRNS,  RGB_RMOD, RGB_VAD,  RGB_HUD,  RGB_SAD,  RGB_SPD,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,            KC_TRNS,
+     KC_TRNS,            KC_LTTOG, KC_LATOG, KC_TKTOG, KC_FCTOG, KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,            KC_TRNS,  KC_TRNS,
+     KC_TRNS,  KC_TRNS,  KC_TRNS,                                KC_TRNS,                                KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS,  KC_TRNS)
+
+};
+
+// clang-format on
+
+void matrix_init_user(void) {
+#ifdef RGB_MATRIX_ENABLE
+    rgb_matrix_init_user();
+#endif
+}
+
+void keyboard_post_init_user(void) {
+    user_config.raw = eeconfig_read_user();
+}
+
+void eeconfig_init_user(void) {
+    user_config.raw = 0;
+    user_config.caps_lock_light_tab = false;
+    user_config.caps_lock_light_alphas = false;
+    user_config.fn_layer_transparent_keys_off = true;
+    user_config.fn_layer_color_enable = false;
+    eeconfig_update_user(user_config.raw);
+}
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case KC_LIGHT_TAB_TOGGLE:
+            if (record->event.pressed) {
+                user_config.caps_lock_light_tab ^= 1; // bitwise xor to toggle status bit
+                eeconfig_update_user(user_config.raw);
+            }
+            return false;  // Skip all further processing of this key
+        case KC_LIGHT_ALPHAS_TOGGLE:
+            if (record->event.pressed) {
+                user_config.caps_lock_light_alphas ^= 1;
+                eeconfig_update_user(user_config.raw);
+            }
+            return false;  // Skip all further processing of this key
+        case KC_FN_LAYER_TRANSPARENT_KEYS_TOGGLE:
+            if (record->event.pressed) {
+                user_config.fn_layer_transparent_keys_off ^= 1;
+                eeconfig_update_user(user_config.raw);
+            }
+            return false;  // Skip all further processing of this key
+        case KC_FN_LAYER_COLOR_TOGGLE:
+            if (record->event.pressed) {
+                user_config.fn_layer_color_enable ^= 1;
+                eeconfig_update_user(user_config.raw);
+            }
+            return false;  // Skip all further processing of this key
+        default:
+            return true;  // Process all other keycodes normally
+    }
+}
+
+bool get_caps_lock_light_tab(void) {
+    return user_config.caps_lock_light_tab;
+}
+
+bool get_caps_lock_light_alphas(void) {
+    return user_config.caps_lock_light_alphas;
+}
+
+bool get_fn_layer_transparent_keys_off(void) {
+    return user_config.fn_layer_transparent_keys_off;
+}
+
+bool get_fn_layer_color_enable(void) {
+    return user_config.fn_layer_color_enable;
+}

--- a/keyboards/keychron/q1/ansi/keymaps/eli/keymap.c
+++ b/keyboards/keychron/q1/ansi/keymaps/eli/keymap.c
@@ -56,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,     KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,            KC_PGUP,
      KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,     KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,             KC_PGDN,
      KC_LSFT,            KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,            KC_RSFT,  KC_UP,
-     KC_LCTL,  KC_LALT,  KC_LGUI,                                KC_SPC,                                 KC_RGUI, MO(MAC_FN),KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT),
+     KC_LCTL,  KC_LGUI,  KC_LALT,                                KC_SPC,                                 KC_RGUI, MO(MAC_FN),KC_RCTL,  KC_LEFT,  KC_DOWN,  KC_RGHT),
 
 [MAC_FN] = LAYOUT_ansi_82(
      KC_TRNS,            KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,    KC_F6,    KC_F7,    KC_F8,    KC_F9,    KC_F10,   KC_F11,   KC_F12,   KC_TRNS,  KC_TRNS,

--- a/keyboards/keychron/q1/ansi/keymaps/eli/keymap_user.h
+++ b/keyboards/keychron/q1/ansi/keymaps/eli/keymap_user.h
@@ -1,0 +1,33 @@
+/* Copyright 2021 @ Mike Killewald
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// clang-format off
+
+enum layers {
+    MAC_BASE,
+    MAC_FN,
+    WIN_BASE,
+    WIN_FN
+};
+
+// clang-format on
+
+bool get_caps_lock_light_tab(void);
+bool get_caps_lock_light_alphas(void);
+bool get_fn_layer_transparent_keys_off(void);
+bool get_fn_layer_color_enable(void);

--- a/keyboards/keychron/q1/ansi/keymaps/eli/readme.md
+++ b/keyboards/keychron/q1/ansi/keymaps/eli/readme.md
@@ -1,0 +1,54 @@
+## mkillewald's Keychron Q1 keymap (ANSI rev_0100) v1.0.4
+
+This keymap builds on the keymap by Grayson Carr (gtg465x) but adds a couple options.
+
+## Features:
+- On macOS, F3 opens Mission Control and F4 opens Launchpad without needing to configure shortcuts in System Preferences
+- RGB lighting turns off when the computer sleeps
+- Caps Lock RGB indicator
+    - the Caps Lock key will light when Caps Lock is enabled with the following options:
+        - #define CAPS_LOCK_INDICATOR_COLOR [color] in config.h to set the backlight color used for the indicator when Caps Lock is enabled (default: red)
+        - Fn+Z will toggle lighting the TAB key when Caps Lock is enabled. This is useful with non backlit keycaps/legends. (default: off)
+        - Fn+X will toggle lighting all the alpha keys when Caps Lock is enabled. (default: off)
+
+- Dynamic Fn layer RGB indicator
+    - When the Fn key is held down, any keys defined on the Fn layer in this firmware or in VIA will be highlighted with the following options:
+        - #define FN_LAYER_COLOR [color] in config.h to set a static color for defined keys (default: orange)
+        - Fn+C will toggle turning off RGB for keys with no definition (default: RGB off)
+        - Fn+V will toggle lighting the defined Fn layer keys with the static color set with FN_LAYER_COLOR (default: static color off)
+
+- All custom keycodes can be moved to different keys in VIA by using the ANY key with the following keycodes:
+    - USER(0) (default: F3) macOS Mission Control
+    - USER(1) (default: F4) macOS Launchpad
+    - USER(2) (default: Fn+Z) Caps Lock light Tab toggle
+    - USER(3) (default: Fn+X) Caps Lock light alphas toggle
+    - USER(4) (default: Fn+C) Fn layer non-defined keys RGB toggle
+    - USER(5) (default: Fn+V) Fn layer defined keys static color toggle
+
+RGB must be toggled on for all indicators to function. If you do not want an RGB mode active but still want the indicators, toggle RGB on and turn the brightness all the way off. The indicators will remain at full brightness.
+
+Please make sure to save any customizations you have made in VIA to a .json file before flashing the firmware. Sometimes it has been necessary to re-apply those changes in VIA after flashing the firmware. If that is the case, you will most likely need to manually add the USER(0) through USER(5) custom keycodes after loading your customizations from the saved .json file. Then re-save a new .json file which will have your previous customizations and the custom keycodes for future use as needed.
+    
+#### USE AT YOUR OWN RISK
+
+## Changelog:
+
+v1.0.4  October 9, 2021
+- Caps Lock and Fn layer toggles are now stored in eeprom so settings will remain when Q1 is unplugged
+
+v1.0.3  October 8, 2021
+- now using keycode toggles instead of preprocessor directive to set the various Caps Lock and Fn Layer RGB lighting options. This allows for setting the options from user space without having to recompile.
+
+v1.0.2  October 7, 2021
+- adapted Grayson Carr's (gtg465x) Caps Lock alphas and dynamic Fn layer RGB routines
+- added CAPS_LOCK_INDICATOR_LIGHT_TAB config option to enable/disable lighting Tab with Caps Lock indicator
+- added FN_LAYER_COLOR config option to set FN layer static color
+
+v1.0.1  October 7, 2021
+- Mission Control and Launchpad custom keycodes are now defined using the VIA user keycodes range so thay can be labeled properly in VIA (adopted change from gtg465x)
+
+v1.0.0  September 30, 2021
+- Initial release built upon keymap by Grayson Carr (gtg465x)
+- defined Mission Control (F3) and Launchpad (F4) keycodes for macOs
+- RGB backlight turns off when computer sleeps
+- added Caps Lock indicator lighting both the Caps Lock and Tab LEDs for better effect on non-backlit keycaps

--- a/keyboards/keychron/q1/ansi/keymaps/eli/rgb_matrix_user.c
+++ b/keyboards/keychron/q1/ansi/keymaps/eli/rgb_matrix_user.c
@@ -1,0 +1,84 @@
+/* Copyright 2021 @ Mike Killewald
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include QMK_KEYBOARD_H
+#include "rgb_matrix_user.h"
+#include "keymap_user.h"
+
+keypos_t led_index_key_position[RGB_MATRIX_LED_COUNT];
+
+void rgb_matrix_init_user(void) {
+    for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+        for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+            uint8_t led_index = g_led_config.matrix_co[row][col];
+            if (led_index != NO_LED) {
+                led_index_key_position[led_index] = (keypos_t){.row = row, .col = col};
+            }
+        }
+    }
+}
+
+bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+    uint8_t current_layer = get_highest_layer(layer_state);
+    switch (current_layer) {
+        case MAC_BASE:
+        case WIN_BASE:
+#ifdef CAPS_LOCK_INDICATOR_COLOR
+            if (host_keyboard_led_state().caps_lock) {
+                rgb_matrix_set_color_by_keycode(led_min, led_max, current_layer, is_caps_lock_indicator, CAPS_LOCK_INDICATOR_COLOR);
+            }
+#endif
+            break;
+        case MAC_FN:
+        case WIN_FN:
+#ifdef FN_LAYER_COLOR
+            if (get_fn_layer_color_enable()) {
+                rgb_matrix_set_color_by_keycode(led_min, led_max, current_layer, is_not_transparent, FN_LAYER_COLOR);
+            }
+#endif
+            if (get_fn_layer_transparent_keys_off()) {
+                rgb_matrix_set_color_by_keycode(led_min, led_max, current_layer, is_transparent, RGB_OFF);
+            }
+            break;
+    }
+    return false;
+}
+
+void rgb_matrix_set_color_by_keycode(uint8_t led_min, uint8_t led_max, uint8_t layer, bool (*is_keycode)(uint16_t), uint8_t red, uint8_t green, uint8_t blue) {
+    for (uint8_t i = led_min; i < led_max; i++) {
+        uint16_t keycode = keymap_key_to_keycode(layer, led_index_key_position[i]);
+        if ((*is_keycode)(keycode)) {
+            rgb_matrix_set_color(i, red, green, blue);
+        }
+    }
+}
+
+bool is_caps_lock_indicator(uint16_t keycode) {
+    bool indicator = keycode == KC_CAPS;
+
+    if (get_caps_lock_light_tab()) {
+        indicator = keycode == KC_TAB || keycode == KC_CAPS;
+    }
+
+    if (get_caps_lock_light_alphas()) {
+        return (KC_A <= keycode && keycode <= KC_Z) || indicator;
+    } else {
+        return indicator;
+    }
+}
+
+bool is_transparent(uint16_t keycode) { return keycode == KC_TRNS; }
+bool is_not_transparent(uint16_t keycode) { return keycode != KC_TRNS; }

--- a/keyboards/keychron/q1/ansi/keymaps/eli/rgb_matrix_user.h
+++ b/keyboards/keychron/q1/ansi/keymaps/eli/rgb_matrix_user.h
@@ -1,0 +1,26 @@
+/* Copyright 2021 @ Mike Killewald
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+void rgb_matrix_init_user(void);
+
+void rgb_matrix_set_color_by_keycode(uint8_t led_min, uint8_t led_max, uint8_t layer, bool (*is_keycode)(uint16_t), uint8_t red, uint8_t green, uint8_t blue);
+
+bool is_caps_lock_indicator(uint16_t keycode);
+bool is_transparent(uint16_t keycode);
+bool is_not_transparent(uint16_t keycode);
+

--- a/keyboards/keychron/q1/ansi/keymaps/eli/rules.mk
+++ b/keyboards/keychron/q1/ansi/keymaps/eli/rules.mk
@@ -1,0 +1,6 @@
+VIA_ENABLE = yes
+MOUSEKEY_ENABLE = no
+
+ifeq ($(strip $(RGB_MATRIX_ENABLE)), yes)
+    SRC += rgb_matrix_user.c
+endif


### PR DESCRIPTION
Added my own keymap for the keychron q1 ansi. It is a copy of mkillewald's profile with the following changes:

- Home / Pg up / Pg dn order swapped around
- swapped Super / LALT key
- FN layer set to green

Let me know if any changes are needed, and thanks!